### PR TITLE
Set the default clock value within FakeAsync.run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
 ## 1.0.0
 
-* Initial version.
+This release contains the `FakeAsync` class that was defined in [`quiver`][].
+It's backwards-compatible with both the `quiver` version *and* the old version
+of the `fake_async` package.
+
+### New Features Relative to `quiver`
+
+* `FakeAsync.elapsed` returns the total amount of fake time elapsed since the
+  `FakeAsync` instance was created.
+
+* `new FakeAsync()` now takes an `initialTime` argument that sets the default
+  time for clocks created with `FakeAsync.getClock()`, and for the `clock`
+  package's top-level `clock` variable.
+
+### New Features Relative to `fake_async` 0.1
+
+* `FakeAsync.periodicTimerCount`, `FakeAsync.nonPeriodicTimerCount`, and
+  `FakeAsync.microtaskCount` provide visibility into the events scheduled within
+  `FakeAsync.run()`.
+
+* `FakeAsync.getClock()` provides access to fully-featured `Clock` objects based
+  on `FakeAsync`'s elapsed time.
+
+* `FakeAsync.flushMicrotasks()` empties the microtask queue without elapsing any
+  time or running any timers.
+
+* `FakeAsync.flushTimers()` runs all microtasks and timers until there are no
+  more scheduled.
+
+## 0.1.2
+
+* Integrate with the clock package.
+

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -62,8 +62,8 @@ class FakeAsync {
 
   /// Creates a [FakeAsync].
   ///
-  /// Within [run], the [`clock`][] field will start at [initialTime] and move
-  /// forward as fake time elapses.
+  /// Within [run], the [`clock`][] property will start at [initialTime] and
+  /// move forward as fake time elapses.
   ///
   /// [`clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/clock.html
   FakeAsync({DateTime initialTime}) {
@@ -78,8 +78,9 @@ class FakeAsync {
   /// already been elapsed. Further calls to [elapse] and [elapseBlocking] will
   /// advance the clock as well.
   ///
-  /// Note that it's usually easier to use the top-level [`clock`][] field. Only
-  /// call this function if you want a different [initialTime] than the default.
+  /// Note that it's usually easier to use the top-level [`clock`][] property.
+  /// Only call this function if you want a different [initialTime] than the
+  /// default.
   ///
   /// [`clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/clock.html
   Clock getClock(DateTime initialTime) =>
@@ -129,10 +130,10 @@ class FakeAsync {
   /// asynchronous features used within [callback] are controlled by calls to
   /// [elapse] rather than the passing of real time.
   ///
-  /// The [`clock`][] field will be set to a clock that reports the fake elapsed
-  /// time. By default, it starts at the time the [FakeAsync] was created
-  /// (according to [`clock.now()`][]), but this can be controlled by passing
-  /// `initialTime` to [new FakeAsync].
+  /// The [`clock`][] property will be set to a clock that reports the fake
+  /// elapsed time. By default, it starts at the time the [FakeAsync] was
+  /// created (according to [`clock.now()`][]), but this can be controlled by
+  /// passing `initialTime` to [new FakeAsync].
   ///
   /// [`clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/clock.html
   /// [`clock.now()`]: https://www.dartdocs.org/documentation/clock/latest/clock/Clock/now.html

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -15,8 +15,8 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
-import 'package:quiver/time.dart';
 
 /// The type of a microtask callback.
 typedef void _Microtask();
@@ -30,6 +30,9 @@ typedef void _Microtask();
 /// The synchronous passage of time (as from blocking or expensive calls) can
 /// also be simulated using [elapseBlocking].
 class FakeAsync {
+  /// The value of [clock] within [run].
+  Clock _clock;
+
   /// The amount of fake time that's elapsed since this [FakeAsync] was
   /// created.
   Duration get elapsed => _elapsed;
@@ -57,12 +60,28 @@ class FakeAsync {
   /// The number of pending microtasks scheduled within a call to [run].
   int get microtaskCount => _microtasks.length;
 
+  /// Creates a [FakeAsync].
+  ///
+  /// Within [run], the [`clock`][] field will start at [initialTime] and move
+  /// forward as fake time elapses.
+  ///
+  /// [`clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/clock.html
+  FakeAsync({DateTime initialTime}) {
+    initialTime ??= clock.now();
+    _clock = new Clock(() => initialTime.add(elapsed));
+  }
+
   /// Returns a fake [Clock] whose time can is elapsed by calls to [elapse] and
   /// [elapseBlocking].
   ///
   /// The returned clock starts at [initialTime] plus the fake time that's
   /// already been elapsed. Further calls to [elapse] and [elapseBlocking] will
   /// advance the clock as well.
+  ///
+  /// Note that it's usually easier to use the top-level [`clock`][] field. Only
+  /// call this function if you want a different [initialTime] than the default.
+  ///
+  /// [`clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/clock.html
   Clock getClock(DateTime initialTime) =>
       new Clock(() => initialTime.add(_elapsed));
 
@@ -110,15 +129,24 @@ class FakeAsync {
   /// asynchronous features used within [callback] are controlled by calls to
   /// [elapse] rather than the passing of real time.
   ///
+  /// The [`clock`][] field will be set to a clock that reports the fake elapsed
+  /// time. By default, it starts at the time the [FakeAsync] was created
+  /// (according to [`clock.now()`][]), but this can be controlled by passing
+  /// `initialTime` to [new FakeAsync].
+  ///
+  /// [`clock`]: https://www.dartdocs.org/documentation/clock/latest/clock/clock.html
+  /// [`clock.now()`]: https://www.dartdocs.org/documentation/clock/latest/clock/Clock/now.html
+  ///
   /// Calls [callback] with `this` as argument and returns its result.
-  T run<T>(T callback(FakeAsync self)) => runZoned(() => callback(this),
-      zoneSpecification: new ZoneSpecification(
-          createTimer: (_, __, ___, duration, callback) =>
-              _createTimer(duration, callback, false),
-          createPeriodicTimer: (_, __, ___, duration, callback) =>
-              _createTimer(duration, callback, true),
-          scheduleMicrotask: (_, __, ___, microtask) =>
-              _microtasks.add(microtask)));
+  T run<T>(T callback(FakeAsync self)) =>
+      runZoned(() => withClock(_clock, () => callback(this)),
+          zoneSpecification: new ZoneSpecification(
+              createTimer: (_, __, ___, duration, callback) =>
+                  _createTimer(duration, callback, false),
+              createPeriodicTimer: (_, __, ___, duration, callback) =>
+                  _createTimer(duration, callback, true),
+              scheduleMicrotask: (_, __, ___, microtask) =>
+                  _microtasks.add(microtask)));
 
   /// Runs all pending microtasks scheduled within a call to [run] until there
   /// are no more microtasks scheduled.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,12 @@ environment:
   sdk: '>=1.24.0 <2.0.0'
 
 dependencies:
+  clock: '^1.0.0'
   collection: '^1.8.0'
-  quiver: '^0.28.0'
 
 dev_dependencies:
   async: '>=1.10.0 <3.0.0'
   test: '^0.12.28'
 
+dependency_overrides:
+  clock: {git: git://github.com/dart-lang/clock}

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 
 import 'package:test/test.dart';
@@ -506,4 +507,60 @@ main() {
       });
     });
   });
+
+  group('clock', () {
+    test('updates following elapse()', () {
+      new FakeAsync().run((async) {
+        var before = clock.now();
+        async.elapse(elapseBy);
+        expect(clock.now(), before.add(elapseBy));
+      });
+    });
+
+    test('updates following elapseBlocking()', () {
+      new FakeAsync().run((async) {
+        var before = clock.now();
+        async.elapseBlocking(elapseBy);
+        expect(clock.now(), before.add(elapseBy));
+      });
+    });
+
+    group('starts at', () {
+      test('the time at which the FakeAsync was created', () {
+        var start = new DateTime.now();
+        new FakeAsync().run((async) {
+          expect(clock.now(), _closeToTime(start));
+          async.elapse(elapseBy);
+          expect(clock.now(), _closeToTime(start.add(elapseBy)));
+        });
+      });
+
+      test('the value of clock.now()', () {
+        var start = new DateTime(1990, 8, 11);
+        withClock(new Clock.fixed(start), () {
+          new FakeAsync().run((async) {
+            expect(clock.now(), start);
+            async.elapse(elapseBy);
+            expect(clock.now(), start.add(elapseBy));
+          });
+        });
+      });
+
+      test('an explicit value', () {
+        var start = new DateTime(1990, 8, 11);
+        new FakeAsync(initialTime: start).run((async) {
+          expect(clock.now(), start);
+          async.elapse(elapseBy);
+          expect(clock.now(), start.add(elapseBy));
+        });
+      });
+    });
+  });
 }
+
+/// Returns a matcher that asserts that a [DateTime] is within 100ms of
+/// [expected].
+Matcher _closeToTime(DateTime expected) => predicate(
+    (actual) =>
+        expected.difference(actual as DateTime).inMilliseconds.abs() < 100,
+    "is close to $expected");


### PR DESCRIPTION
This brings this package to full API compatibility with fake_async
0.1.