### PR TITLE
Expose FakeTimer, add FakeAsync.pendingTimers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+   * Added `FakeAsync.pendingTimersDebugInfo` (ported from quiver).
+
 ## 1.0.2
 
 * Update min SDK to 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.1.0
 
-   * Added `FakeAsync.pendingTimersDebugInfo` (ported from quiver).
+   * Exposed the `FakeTimer` class as a public class.
+   * Added `FakeAsync.pendingTimers` which gives access to all pending timers
+     at the time of the call.
 
 ## 1.0.2
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -68,6 +68,10 @@ class FakeAsync {
   /// All timers created within [run].
   final _timers = <_FakeTimer>{};
 
+  /// Debugging information for all pending timers.
+  List<String> get pendingTimersDebugInfo =>
+      _timers.map((timer) => '${timer.debugInfo}').toList(growable: false);
+
   /// The number of active periodic timers created within a call to [run] or
   /// [fakeAsync].
   int get periodicTimerCount =>
@@ -272,13 +276,23 @@ class _FakeTimer implements Timer {
   /// fired.
   Duration _nextCall;
 
+  /// The current stack trace when this timer was created.
+  final StackTrace _creationStackTrace;
+
   @override
   int get tick {
     throw UnimplementedError('tick');
   }
 
+  /// Returns debugging information to try to identify the source of the
+  /// [Timer].
+  String get debugInfo =>
+      'Timer (duration: $_duration, periodic: $_isPeriodic), created:\n'
+      '$_creationStackTrace';
+
   _FakeTimer(Duration duration, this._callback, this._isPeriodic, this._async)
-      : _duration = duration < Duration.zero ? Duration.zero : duration {
+      : _duration = duration < Duration.zero ? Duration.zero : duration,
+        _creationStackTrace = StackTrace.current {
     _nextCall = _async._elapsed + _duration;
   }
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -74,7 +74,7 @@ class FakeAsync {
   /// line and will contain the stack trace from its construction on subsequent
   /// lines.  The stack trace can passed to [StackTrace.fromString].
   List<String> get pendingTimersDebugInfo =>
-      _timers.map((timer) => '${timer.debugInfo}').toList(growable: false);
+      _timers.map((timer) => timer.debugInfo).toList(growable: false);
 
   /// The number of active periodic timers created within a call to [run] or
   /// [fakeAsync].
@@ -281,7 +281,7 @@ class _FakeTimer implements Timer {
   Duration _nextCall;
 
   /// The current stack trace when this timer was created.
-  final StackTrace _creationStackTrace;
+  final _creationStackTrace = StackTrace.current;
 
   @override
   int get tick {
@@ -297,8 +297,7 @@ class _FakeTimer implements Timer {
       '$_creationStackTrace';
 
   _FakeTimer(Duration duration, this._callback, this._isPeriodic, this._async)
-      : _duration = duration < Duration.zero ? Duration.zero : duration,
-        _creationStackTrace = StackTrace.current {
+      : _duration = duration < Duration.zero ? Duration.zero : duration {
     _nextCall = _async._elapsed + _duration;
   }
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -69,6 +69,10 @@ class FakeAsync {
   final _timers = <_FakeTimer>{};
 
   /// Debugging information for all pending timers.
+  ///
+  /// Each returned [String] will contain details about the [Timer] in its first
+  /// line and will contain the stack trace from its construction on subsequent
+  /// lines.  The stack trace can passed to [StackTrace.fromString].
   List<String> get pendingTimersDebugInfo =>
       _timers.map((timer) => '${timer.debugInfo}').toList(growable: false);
 
@@ -286,6 +290,8 @@ class _FakeTimer implements Timer {
 
   /// Returns debugging information to try to identify the source of the
   /// [Timer].
+  ///
+  /// See [FakeAsync.pendingTimersDebugInfo] for requirements on the format.
   String get debugInfo =>
       'Timer (duration: $_duration, periodic: $_isPeriodic), created:\n'
       '$_creationStackTrace';

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -280,7 +280,7 @@ class FakeTimer implements Timer {
   Duration _nextCall;
 
   /// The current stack trace when this timer was created.
-  final _creationStackTrace = StackTrace.current;
+  final creationStackTrace = StackTrace.current;
 
   @override
   int get tick {
@@ -291,7 +291,7 @@ class FakeTimer implements Timer {
   /// [Timer].
   String get debugString =>
       'Timer (duration: $duration, periodic: $isPeriodic), created:\n'
-      '$_creationStackTrace';
+      '$creationStackTrace';
 
   FakeTimer._(Duration duration, this._callback, this.isPeriodic, this._async)
       : duration = duration < Duration.zero ? Duration.zero : duration {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fake_async
-version: 1.0.2-dev
+version: 1.1.0
 description: Fake asynchronous events such as timers and microtasks for deterministic testing.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/fake_async

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -484,6 +484,33 @@ void main() {
         expect(async.nonPeriodicTimerCount, 0);
       });
     });
+
+    test('should report debugging information of pending timers', () {
+      FakeAsync().run((fakeAsync) {
+        expect(fakeAsync.pendingTimersDebugInfo, isEmpty);
+        // Use `dynamic` so we can access `_FakeTimer` internals.
+        dynamic nonPeriodic = Timer(const Duration(seconds: 1), () {});
+        dynamic periodic =
+            Timer.periodic(const Duration(seconds: 2), (Timer timer) {});
+        final debugInfo = fakeAsync.pendingTimersDebugInfo;
+        expect(debugInfo.length, 2);
+        expect(
+          debugInfo,
+          containsAll([
+            nonPeriodic.debugInfo,
+            periodic.debugInfo,
+          ]),
+        );
+
+        const thisFileName = 'fake_async_test.dart';
+        expect(nonPeriodic.debugInfo, contains(':01.0'));
+        expect(nonPeriodic.debugInfo, contains('periodic: false'));
+        expect(nonPeriodic.debugInfo, contains(thisFileName));
+        expect(periodic.debugInfo, contains(':02.0'));
+        expect(periodic.debugInfo, contains('periodic: true'));
+        expect(periodic.debugInfo, contains(thisFileName));
+      });
+    });
   });
 
   group('timers', () {

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -487,28 +487,29 @@ void main() {
 
     test('should report debugging information of pending timers', () {
       FakeAsync().run((fakeAsync) {
-        expect(fakeAsync.pendingTimersDebugInfo, isEmpty);
+        expect(fakeAsync.pendingTimers, isEmpty);
         // Use `dynamic` so we can access `_FakeTimer` internals.
-        dynamic nonPeriodic = Timer(const Duration(seconds: 1), () {});
-        dynamic periodic =
-            Timer.periodic(const Duration(seconds: 2), (Timer timer) {});
-        final debugInfo = fakeAsync.pendingTimersDebugInfo;
+        var nonPeriodic = Timer(const Duration(seconds: 1), () {}) as FakeTimer;
+        var periodic =
+            Timer.periodic(const Duration(seconds: 2), (Timer timer) {})
+                as FakeTimer;
+        final debugInfo = fakeAsync.pendingTimers;
         expect(debugInfo.length, 2);
         expect(
           debugInfo,
           containsAll([
-            nonPeriodic.debugInfo,
-            periodic.debugInfo,
+            nonPeriodic,
+            periodic,
           ]),
         );
 
         const thisFileName = 'fake_async_test.dart';
-        expect(nonPeriodic.debugInfo, contains(':01.0'));
-        expect(nonPeriodic.debugInfo, contains('periodic: false'));
-        expect(nonPeriodic.debugInfo, contains(thisFileName));
-        expect(periodic.debugInfo, contains(':02.0'));
-        expect(periodic.debugInfo, contains('periodic: true'));
-        expect(periodic.debugInfo, contains(thisFileName));
+        expect(nonPeriodic.debugString, contains(':01.0'));
+        expect(nonPeriodic.debugString, contains('periodic: false'));
+        expect(nonPeriodic.debugString, contains(thisFileName));
+        expect(periodic.debugString, contains(':02.0'));
+        expect(periodic.debugString, contains('periodic: true'));
+        expect(periodic.debugString, contains(thisFileName));
       });
     });
   });

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -488,7 +488,6 @@ void main() {
     test('should report debugging information of pending timers', () {
       FakeAsync().run((fakeAsync) {
         expect(fakeAsync.pendingTimers, isEmpty);
-        // Use `dynamic` so we can access `_FakeTimer` internals.
         var nonPeriodic = Timer(const Duration(seconds: 1), () {}) as FakeTimer;
         var periodic =
             Timer.periodic(const Duration(seconds: 2), (Timer timer) {})


### PR DESCRIPTION
Ports https://github.com/google/quiver-dart/commit/0a282a82125b011152fab57185f9d39cfe71b12e to this package.

This is necessary to migrate `flutter_test` to use this package and drop its quiver dependency.

cc @jonahwilliams