### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0-nullsafety.1
+
+* Allow 2.10 stable and 2.11.0 dev SDK versions.
+
 ## 1.2.0-nullsafety
 
 Pre-release for the null safety migration of this package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fake_async
-version: 1.2.0-nullsafety
+version: 1.2.0-nullsafety.1
 description: >-
   Fake asynchronous events such as timers and microtasks for deterministic
   testing.
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/fake_async
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   clock: '>=1.1.0-nullsafety <1.1.0'


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.