### PR TITLE
Refactor a late final field without initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.0-nullsafety.2-dev
+
 ## 1.2.0-nullsafety.1
 
 * Allow 2.10 stable and 2.11.0 dev SDK versions.

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -49,8 +49,10 @@ T fakeAsync<T>(T Function(FakeAsync async) callback, {DateTime? initialTime}) =>
 /// The synchronous passage of time (as from blocking or expensive calls) can
 /// also be simulated using [elapseBlocking].
 class FakeAsync {
+  final DateTime _initialTime;
+
   /// The value of [clock] within [run].
-  late final Clock _clock;
+  late final Clock _clock = Clock(() => _initialTime.add(elapsed));
 
   /// The amount of fake time that's elapsed since this [FakeAsync] was
   /// created.
@@ -98,10 +100,8 @@ class FakeAsync {
   ///
   /// Note: it's usually more convenient to use [fakeAsync] rather than creating
   /// a [FakeAsync] object and calling [run] manually.
-  FakeAsync({DateTime? initialTime}) {
-    var nonNullInitialTime = initialTime ?? clock.now();
-    _clock = Clock(() => nonNullInitialTime.add(elapsed));
-  }
+  FakeAsync({DateTime? initialTime})
+      : _initialTime = initialTime ?? clock.now();
 
   /// Returns a fake [Clock] whose time can is elapsed by calls to [elapse] and
   /// [elapseBlocking].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fake_async
-version: 1.2.0-nullsafety.1
+version: 1.2.0-nullsafety.2-dev
 description: >-
   Fake asynchronous events such as timers and microtasks for deterministic
   testing.


### PR DESCRIPTION
This does require an extra field on the class, but by using an
initializer expression with a `late final` field we avoid the appearance
of a risky pattern.