### PR TITLE
Add values to FakeTimer tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0-dev
+
+* `FakeTimer.tick` will return a value instead of throwing.
+
 ## 1.2.0
 
 * Stable release for null safety.

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -283,10 +283,10 @@ class FakeTimer implements Timer {
   /// The current stack trace when this timer was created.
   final creationStackTrace = StackTrace.current;
 
+  var _tick = 0;
+
   @override
-  int get tick {
-    throw UnimplementedError('tick');
-  }
+  int get tick => _tick;
 
   /// Returns debugging information to try to identify the source of the
   /// [Timer].
@@ -308,6 +308,7 @@ class FakeTimer implements Timer {
   /// Fires this timer's callback and updates its state as necessary.
   void _fire() {
     assert(isActive);
+    _tick++;
     if (isPeriodic) {
       _callback(this);
       _nextCall += duration;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fake_async
-version: 1.2.0
+version: 1.3.0-dev
 description: >-
   Fake asynchronous events such as timers and microtasks for deterministic
   testing.

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -526,6 +526,31 @@ void main() {
         expect(timer.isActive, isFalse);
       });
     });
+
+    test('should increment tick in a non-periodic timer', () {
+      return FakeAsync().run((async) {
+        late Timer timer;
+        timer = Timer(elapseBy, expectAsync0(() {
+          expect(timer.tick, 1);
+        }));
+
+        expect(timer.tick, 0);
+        async.elapse(elapseBy);
+      });
+    });
+
+    test('should increment tick in a periodic timer', () {
+      return FakeAsync().run((async) {
+        final ticks = [];
+        Timer.periodic(
+            elapseBy,
+            expectAsync1((timer) {
+              ticks.add(timer.tick);
+            }, count: 2));
+        async..elapse(elapseBy)..elapse(elapseBy);
+        expect(ticks, [1, 2]);
+      });
+    });
   });
 
   group('clock', () {


### PR DESCRIPTION
In a real timer the tick count can go up by more than the number of
times the callback was invoked if a period is missed. In the FakeAsync
case the `tick` matches the number of times the callback was invoked.