### PR TITLE
Allow FakeAsync to disable creation StackTraces in FakeTimers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.3.0-dev
 
 * `FakeTimer.tick` will return a value instead of throwing.
+* `FakeAsync.includeTimerStackTrace` allows controlling whether timers created
+   with a FakeAsync will include a creation Stack Trace.
 
 ## 1.2.0
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -287,8 +287,8 @@ class FakeTimer implements Timer {
 
   /// The current stack trace when this timer was created.
   ///
-  /// If the [FakeAsync] instance that created this has includeTimerStackTrace
-  /// set to false, then accessing this field will throw a [TypeError].
+  /// If [FakeAsync.includeTimerStackTrace] is set to false then accessing
+  /// this field will throw a [TypeError].
   StackTrace get creationStackTrace => _creationStackTrace!;
   final StackTrace? _creationStackTrace;
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -57,6 +57,10 @@ class FakeAsync {
   Duration get elapsed => _elapsed;
   var _elapsed = Duration.zero;
 
+  /// Whether Timers created by this FakeAsync will include a creation stack
+  /// trace in [FakeAsync.pendingTimersDebugString].
+  final bool includeTimerStackTrace;
+
   /// The fake time at which the current call to [elapse] will finish running.
   ///
   /// This is `null` if there's no current call to [elapse].
@@ -98,7 +102,7 @@ class FakeAsync {
   ///
   /// Note: it's usually more convenient to use [fakeAsync] rather than creating
   /// a [FakeAsync] object and calling [run] manually.
-  FakeAsync({DateTime? initialTime}) {
+  FakeAsync({DateTime? initialTime, this.includeTimerStackTrace = true}) {
     var nonNullInitialTime = initialTime ?? clock.now();
     _clock = Clock(() => nonNullInitialTime.add(elapsed));
   }
@@ -245,7 +249,8 @@ class FakeAsync {
   /// Creates a new timer controlled by `this` that fires [callback] after
   /// [duration] (or every [duration] if [periodic] is `true`).
   Timer _createTimer(Duration duration, Function callback, bool periodic) {
-    var timer = FakeTimer._(duration, callback, periodic, this);
+    var timer = FakeTimer._(duration, callback, periodic, this,
+        includeStackTrace: includeTimerStackTrace);
     _timers.add(timer);
     return timer;
   }
@@ -281,7 +286,8 @@ class FakeTimer implements Timer {
   late Duration _nextCall;
 
   /// The current stack trace when this timer was created.
-  final creationStackTrace = StackTrace.current;
+  StackTrace get creationStackTrace => _creationStackTrace!;
+  final StackTrace? _creationStackTrace;
 
   var _tick = 0;
 
@@ -290,12 +296,13 @@ class FakeTimer implements Timer {
 
   /// Returns debugging information to try to identify the source of the
   /// [Timer].
-  String get debugString =>
-      'Timer (duration: $duration, periodic: $isPeriodic), created:\n'
-      '$creationStackTrace';
+  String get debugString => 'Timer (duration: $duration, periodic: $isPeriodic)'
+      '${_creationStackTrace != null ? ', created:\n$creationStackTrace' : ''}';
 
-  FakeTimer._(Duration duration, this._callback, this.isPeriodic, this._async)
-      : duration = duration < Duration.zero ? Duration.zero : duration {
+  FakeTimer._(Duration duration, this._callback, this.isPeriodic, this._async,
+      {bool includeStackTrace = true})
+      : duration = duration < Duration.zero ? Duration.zero : duration,
+        _creationStackTrace = includeStackTrace ? StackTrace.current : null {
     _nextCall = _async._elapsed + this.duration;
   }
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -286,6 +286,9 @@ class FakeTimer implements Timer {
   late Duration _nextCall;
 
   /// The current stack trace when this timer was created.
+  ///
+  /// If the [FakeAsync] instance that created this has includeTimerStackTrace
+  /// set to false, then accessing this field will throw a [TypeError].
   StackTrace get creationStackTrace => _creationStackTrace!;
   final StackTrace? _creationStackTrace;
 

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -511,6 +511,35 @@ void main() {
         expect(periodic.debugString, contains(thisFileName));
       });
     });
+
+    test(
+        'should report debugging information of pending timers excluding stack traces',
+        () {
+      FakeAsync(includeTimerStackTrace: false).run((fakeAsync) {
+        expect(fakeAsync.pendingTimers, isEmpty);
+        var nonPeriodic = Timer(const Duration(seconds: 1), () {}) as FakeTimer;
+        var periodic =
+            Timer.periodic(const Duration(seconds: 2), (Timer timer) {})
+                as FakeTimer;
+        final debugInfo = fakeAsync.pendingTimers;
+        expect(debugInfo.length, 2);
+        expect(
+          debugInfo,
+          containsAll([
+            nonPeriodic,
+            periodic,
+          ]),
+        );
+
+        const thisFileName = 'fake_async_test.dart';
+        expect(nonPeriodic.debugString, contains(':01.0'));
+        expect(nonPeriodic.debugString, contains('periodic: false'));
+        expect(nonPeriodic.debugString, isNot(contains(thisFileName)));
+        expect(periodic.debugString, contains(':02.0'));
+        expect(periodic.debugString, contains('periodic: true'));
+        expect(periodic.debugString, isNot(contains(thisFileName)));
+      });
+    });
   });
 
   group('timers', () {


### PR DESCRIPTION
I am currently using FakeAsync in a prototype microbenchmark suite. The eager stack trace creation for timers is fairly expensive and ends up showing up in the top ~N CPU %. 

This patch allows this functionality to be disabled in the FakeAsync constructor by passing includeTimerStackTrace: false (the default is true). This patch avoids a breaking change to the FakeTimer api using a null checked getter which can throw, but only if the user has opted into a new parameter.