### PR TITLE
Enable and fix lines_longer_than_80_chars

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -43,6 +43,7 @@ linter:
     - join_return_with_assignment
     - library_names
     - library_prefixes
+    - lines_longer_than_80_chars
     - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -513,8 +513,8 @@ void main() {
     });
 
     test(
-        'should report debugging information of pending timers excluding stack traces',
-        () {
+        'should report debugging information of pending timers excluding '
+        'stack traces', () {
       FakeAsync(includeTimerStackTrace: false).run((fakeAsync) {
         expect(fakeAsync.pendingTimers, isEmpty);
         var nonPeriodic = Timer(const Duration(seconds: 1), () {}) as FakeTimer;


### PR DESCRIPTION
I missed a long string in a recent PR. Enable the lint to avoid relying
on human reviewers.