### PR TITLE
Add option to automatically progress microtasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 1.3.2-wip
 
 * Require Dart 3.0.0
+* Add `autoMicrotask` to `FakeAsync` constructor and `fakeAsync` helper.
+  If enabled, scheduled microtasks run automatically without needing 
+  time to be elapsed or microtask queue to be flushed.
+* Runs timer and microtask callbacks in the scheduling zone, 
+  and if they throw, the error is reported in that zone.
 
 ## 1.3.1
 


### PR DESCRIPTION
If `autoMicrotasks` is set to `true` when creating `FakeAsync` or calling `fakeAsync`, the microtask
queue will automatically be flushed by a microtask from the parent zone.

For tests that only care about larger-grained timers, this can make it easier to ensure progress for intermediate computations.

Also binds timer and microtask callbacks in their originating zone, to ensure they are run there, and that unhandled errors get reported in that zone.

