### PR TITLE
Add FakeAsync.runNextTimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.3.2-wip
+## 1.4.0-wip
 
 * Require Dart 3.3
+* Add `FakeAsync.runNextTimer`, a single-step analogue
+  of `FakeAsync.flushTimers`.
 
 ## 1.3.1
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -138,7 +138,7 @@ class FakeAsync {
     }
 
     _elapsingTo = _elapsed + duration;
-    while (_runNextTimer(_elapsingTo!)) {}
+    while (runNextTimer(until: _elapsingTo!)) {}
     _elapseTo(_elapsingTo!);
     _elapsingTo = null;
   }
@@ -222,7 +222,7 @@ class FakeAsync {
         }
       }
 
-      if (!_runNextTimer(absoluteTimeout)) {
+      if (!runNextTimer(until: absoluteTimeout)) {
         if (_timers.isEmpty) break;
 
         // TODO(nweiz): Make this a [TimeoutException].
@@ -242,19 +242,15 @@ class FakeAsync {
   /// and again after the timer runs.
   /// Before the timer runs, [elapsed] is updated to the appropriate value.
   ///
-  /// When [within] is non-null, only timers that are due within the
-  /// given duration will be considered.
+  /// When [until] is non-null, only timers due up until the given time
+  /// will be considered, in terms of [elapsed].
   ///
   /// Because multiple timers may be due at the same time, a call to this
   /// method may leave the time advanced to where other timers are due.
   /// Doing an `elapse(Duration.zero)` afterwards may trigger more timers.
   ///
   /// Returns `true` if a timer was run, `false` otherwise.
-  bool runNextTimer({Duration? within}) {
-    return _runNextTimer(within == null ? null : _elapsed + within);
-  }
-
-  bool _runNextTimer([Duration? until]) {
+  bool runNextTimer({Duration? until}) {
     flushMicrotasks();
 
     if (_timers.isEmpty) return false;

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -233,12 +233,21 @@ class FakeAsync {
 
   /// Elapses time to run one timer, if any timer exists.
   ///
+  /// Running one timer at a time, rather than just advancing time such as
+  /// with [elapse] or [flushTimers], can be useful if a test wants to run
+  /// its own logic between each timer event, for example to verify invariants
+  /// or to end the test early in case of an error.
+  ///
   /// Microtasks are flushed before identifying the timer to run,
   /// and again after the timer runs.
   /// Before the timer runs, [elapsed] is updated to the appropriate value.
   ///
   /// When [within] is non-null, only timers that are due within the
   /// given duration will be considered.
+  ///
+  /// Because multiple timers may be due at the same time, a call to this
+  /// method may leave the time advanced to where other timers are due.
+  /// Doing an `elapse(Duration.zero)` afterwards may trigger more timers.
   ///
   /// Returns `true` if a timer was run, `false` otherwise.
   bool runNextTimer({Duration? within}) {

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -247,7 +247,12 @@ class FakeAsync {
   ///
   /// Because multiple timers may be due at the same time, a call to this
   /// method may leave the time advanced to where other timers are due.
-  /// Doing an `elapse(Duration.zero)` afterwards may trigger more timers.
+  /// Calling `elapse(Duration.zero)` afterwards may trigger more timers.
+  ///
+  /// If microtasks or timer callbacks make their own calls to methods on this
+  /// [FakeAsync], then a call to this method may indirectly cause more timers
+  /// to run beyond the timer it runs directly, and may cause [elapsed] to
+  /// advance beyond [until].  Any such timers are ignored in the return value.
   ///
   /// Returns `true` if a timer was run, `false` otherwise.
   bool runNextTimer({Duration? until}) {

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -217,7 +217,7 @@ class FakeAsync {
         throw StateError('Exceeded timeout $timeout while flushing timers');
       }
 
-      if (flushPeriodicTimers) return _timers.isNotEmpty;
+      if (flushPeriodicTimers) return true;
 
       // Continue firing timers until the only ones left are periodic *and*
       // every periodic timer has had a change to run against the final

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -237,12 +237,12 @@ class FakeAsync {
   /// and again after the timer runs.
   /// Before the timer runs, [elapsed] is updated to the appropriate value.
   ///
-  /// The [timeout] controls how much fake time may elapse. If non-null,
-  /// then timers further in the future than the given duration will be ignored.
+  /// When [within] is non-null, only timers that are due within the
+  /// given duration will be considered.
   ///
   /// Returns `true` if a timer was run, `false` otherwise.
-  bool runNextTimer({Duration? timeout}) {
-    return _runNextTimer(timeout == null ? null : _elapsed + timeout);
+  bool runNextTimer({Duration? within}) {
+    return _runNextTimer(within == null ? null : _elapsed + within);
   }
 
   bool _runNextTimer([Duration? until]) {

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -138,7 +138,7 @@ class FakeAsync {
     }
 
     _elapsingTo = _elapsed + duration;
-    while (runNextTimer(timeout: _elapsingTo! - _elapsed)) {}
+    while (_runNextTimer(_elapsingTo!)) {}
     _elapseTo(_elapsingTo!);
     _elapsingTo = null;
   }
@@ -222,7 +222,7 @@ class FakeAsync {
         }
       }
 
-      if (!runNextTimer(timeout: absoluteTimeout - _elapsed)) {
+      if (!_runNextTimer(absoluteTimeout)) {
         if (_timers.isEmpty) break;
 
         // TODO(nweiz): Make this a [TimeoutException].
@@ -242,13 +242,15 @@ class FakeAsync {
   ///
   /// Returns `true` if a timer was run, `false` otherwise.
   bool runNextTimer({Duration? timeout}) {
-    final absoluteTimeout = timeout == null ? null : _elapsed + timeout;
+    return _runNextTimer(timeout == null ? null : _elapsed + timeout);
+  }
 
+  bool _runNextTimer([Duration? until]) {
     flushMicrotasks();
 
     if (_timers.isEmpty) return false;
     final timer = minBy(_timers, (FakeTimer timer) => timer._nextCall)!;
-    if (absoluteTimeout != null && timer._nextCall > absoluteTimeout) {
+    if (until != null && timer._nextCall > until) {
       return false;
     }
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -211,7 +211,7 @@ class FakeAsync {
       {Duration timeout = const Duration(hours: 1),
       bool flushPeriodicTimers = true}) {
     final absoluteTimeout = _elapsed + timeout;
-    for (;;) {
+    while (true) {
       // With [flushPeriodicTimers] false, continue firing timers only until
       // all remaining timers are periodic *and* every periodic timer has had
       // a chance to run against the final value of [_elapsed].
@@ -233,13 +233,14 @@ class FakeAsync {
 
   /// Elapses time to run one timer, if any timer exists.
   ///
-  /// Microtasks are flushed before and after the timer runs. Before the
-  /// timer runs, [elapsed] is updated to the appropriate value.
+  /// Microtasks are flushed before identifying the timer to run,
+  /// and again after the timer runs.
+  /// Before the timer runs, [elapsed] is updated to the appropriate value.
   ///
   /// The [timeout] controls how much fake time may elapse. If non-null,
   /// then timers further in the future than the given duration will be ignored.
   ///
-  /// Returns true if a timer was run, false otherwise.
+  /// Returns `true` if a timer was run, `false` otherwise.
   bool runNextTimer({Duration? timeout}) {
     final absoluteTimeout = timeout == null ? null : _elapsed + timeout;
 

--- a/lib/fake_async.dart
+++ b/lib/fake_async.dart
@@ -217,13 +217,15 @@ class FakeAsync {
         throw StateError('Exceeded timeout $timeout while flushing timers');
       }
 
-      if (flushPeriodicTimers) return true;
+      // With [flushPeriodicTimers] false, continue firing timers only until
+      // all remaining timers are periodic *and* every periodic timer has had
+      // a chance to run against the final value of [_elapsed].
+      if (!flushPeriodicTimers) {
+        return !_timers
+            .every((timer) => timer.isPeriodic && timer._nextCall > _elapsed);
+      }
 
-      // Continue firing timers until the only ones left are periodic *and*
-      // every periodic timer has had a change to run against the final
-      // value of [_elapsed].
-      return _timers
-          .any((timer) => !timer.isPeriodic || timer._nextCall <= _elapsed);
+      return true;
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fake_async
-version: 1.3.2-wip
+version: 1.4.0-wip
 description: >-
   Fake asynchronous events such as timers and microtasks for deterministic
   testing.

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -503,35 +503,35 @@ void main() {
       });
     });
 
-    test('should apply timeout', () {
+    test('should apply `within`', () {
       FakeAsync().run((async) {
         var ran = false;
         Timer(const Duration(days: 1), () => ran = true);
-        expect(async.runNextTimer(timeout: const Duration(hours: 1)), false);
+        expect(async.runNextTimer(within: const Duration(hours: 1)), false);
         expect(ran, false);
       });
     });
 
-    test('should apply timeout as non-strict bound', () {
+    test('should apply `within` as non-strict bound', () {
       FakeAsync().run((async) {
         var ran = false;
         Timer(const Duration(hours: 1), () => ran = true);
-        expect(async.runNextTimer(timeout: const Duration(hours: 1)), true);
+        expect(async.runNextTimer(within: const Duration(hours: 1)), true);
         expect(ran, true);
       });
     });
 
-    test('should apply timeout relative to current time', () {
+    test('should apply `within` relative to current time', () {
       FakeAsync().run((async) {
         var ran = false;
         Timer(const Duration(hours: 3), () => ran = true);
         async.elapse(const Duration(hours: 2));
-        expect(async.runNextTimer(timeout: const Duration(hours: 2)), true);
+        expect(async.runNextTimer(within: const Duration(hours: 2)), true);
         expect(ran, true);
       });
     });
 
-    test('should have no timeout by default', () {
+    test('should have no time bound by default', () {
       FakeAsync().run((async) {
         var ran = false;
         Timer(const Duration(microseconds: 1 << 52), () => ran = true);

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -500,6 +500,15 @@ void main() {
         Timer(const Duration(days: 1), () => time = async.elapsed);
         expect(async.runNextTimer(), true);
         expect(time, const Duration(days: 1));
+        expect(async.elapsed, const Duration(days: 1));
+      });
+    });
+
+    test('should not update elapsed if no timers exist', () {
+      FakeAsync().run((async) {
+        async.elapse(const Duration(hours: 1));
+        expect(async.runNextTimer(), false);
+        expect(async.elapsed, const Duration(hours: 1));
       });
     });
 
@@ -509,6 +518,14 @@ void main() {
         Timer(const Duration(days: 1), () => ran = true);
         expect(async.runNextTimer(until: const Duration(hours: 1)), false);
         expect(ran, false);
+      });
+    });
+
+    test('should not update elapsed if all timers are past `until`', () {
+      FakeAsync().run((async) {
+        Timer(const Duration(days: 1), () {});
+        expect(async.runNextTimer(until: const Duration(hours: 1)), false);
+        expect(async.elapsed, Duration.zero);
       });
     });
 
@@ -526,8 +543,11 @@ void main() {
         var ran = false;
         Timer(const Duration(hours: 3), () => ran = true);
         async.elapse(const Duration(hours: 1));
+
         expect(async.runNextTimer(until: const Duration(hours: 2)), false);
         expect(ran, false);
+        expect(async.elapsed, const Duration(hours: 1));
+
         expect(async.runNextTimer(until: const Duration(hours: 3)), true);
         expect(ran, true);
       });

--- a/test/fake_async_test.dart
+++ b/test/fake_async_test.dart
@@ -503,30 +503,32 @@ void main() {
       });
     });
 
-    test('should apply `within`', () {
+    test('should apply `until`', () {
       FakeAsync().run((async) {
         var ran = false;
         Timer(const Duration(days: 1), () => ran = true);
-        expect(async.runNextTimer(within: const Duration(hours: 1)), false);
+        expect(async.runNextTimer(until: const Duration(hours: 1)), false);
         expect(ran, false);
       });
     });
 
-    test('should apply `within` as non-strict bound', () {
+    test('should apply `until` as non-strict bound', () {
       FakeAsync().run((async) {
         var ran = false;
         Timer(const Duration(hours: 1), () => ran = true);
-        expect(async.runNextTimer(within: const Duration(hours: 1)), true);
+        expect(async.runNextTimer(until: const Duration(hours: 1)), true);
         expect(ran, true);
       });
     });
 
-    test('should apply `within` relative to current time', () {
+    test('should apply `until` relative to start', () {
       FakeAsync().run((async) {
         var ran = false;
         Timer(const Duration(hours: 3), () => ran = true);
-        async.elapse(const Duration(hours: 2));
-        expect(async.runNextTimer(within: const Duration(hours: 2)), true);
+        async.elapse(const Duration(hours: 1));
+        expect(async.runNextTimer(until: const Duration(hours: 2)), false);
+        expect(ran, false);
+        expect(async.runNextTimer(until: const Duration(hours: 3)), true);
         expect(ran, true);
       });
     });


### PR DESCRIPTION
Fixes dart-lang/test#2318.

This method is like flushTimers, but runs just one timer and then returns.
That allows the caller to write their own loop similar to flushTimers
but with custom logic of their own.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
